### PR TITLE
:arrow_down: Downgrade Pillow dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ django-cloudinary-storage==0.3.0
 django-storages==1.12.3
 gunicorn==22.0.0
 idna==3.7
-Pillow==10.3.0
+Pillow==9.5.0
 psycopg2-binary==2.9.6
 python-dateutil==2.8.2
 python-environ==0.4.54


### PR DESCRIPTION
Pillow 10.3.0, which I introduced in a previous commit, requires a Python version newer than 3.7.10. This version is currently used in your Render deployment environment and has been causing deployment failures.

I will now downgrade Pillow to version 9.5.0, which is the last version to support Python 3.7. This should resolve the deployment issue on Render.

I still highly recommend that you upgrade the Python version in your Render environment to a maintained version. This will ensure you have access to the latest security updates and package features for all dependencies.